### PR TITLE
Upgrade Base Image tag to Debian 9 Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:8.3
-MAINTAINER Michał Czeraszkiewicz <contact@czerasz.com>
+FROM debian:9
+LABEL MAINTAINER="Michał Czeraszkiewicz <contact@czerasz.com>"
 
 RUN apt-get update && \
     apt-get -y install putty-tools && \


### PR DESCRIPTION
Fixes this error which happens when trying to build :

```shell
$ sh scripts/build.sh 

Sending build context to Docker daemon  57.86kB
Step 1/5 : FROM debian:8.3
8.3: Pulling from library/debian
fdd5d7827f33: Pull complete 
a3ed95caeb02: Pull complete 
Digest: sha256:0a2584122bc0b7c87b7c0e5fe2ae789c8b99bde3e2e53461da56b4b7c9108a08
Status: Downloaded newer image for debian:8.3
 ---> f50f9524513f
Step 2/5 : MAINTAINER Michał Czeraszkiewicz <contact@czerasz.com>
 ---> Running in e9c070b0d973
Removing intermediate container e9c070b0d973
 ---> eb76966c60d0
Step 3/5 : RUN apt-get update &&     apt-get -y install putty-tools &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ---> Running in cfb5768f861a
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://httpredir.debian.org jessie InRelease
Get:2 http://httpredir.debian.org jessie-updates InRelease [7340 B]
Get:3 http://httpredir.debian.org jessie Release.gpg [2420 B]
Get:4 http://httpredir.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [832 kB]
Get:6 http://httpredir.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.1 MB in 10s (993 kB/s)
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update &&     apt-get -y install putty-tools &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*' returned a non-zero code: 100
```